### PR TITLE
Remove the possibility to change the endpoint

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -151,16 +151,6 @@ class Client
     }
 
     /**
-     * Set the Slack endpoint.
-     *
-     * @param string $endpoint
-     */
-    public function setEndpoint($endpoint): void
-    {
-        $this->endpoint = $endpoint;
-    }
-
-    /**
      * Get the default channel messages will be created for.
      *
      * @return string


### PR DESCRIPTION
Multiple `Slack` instance should be used instead.

It's a preparation for #6 