### PR TITLE
Reintroduce Client::to and Client::send pseudo magic methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -83,6 +83,24 @@ final class Client
     }
 
     /**
+     * @param string $channel
+     * @return Message
+     */
+    public function to(string $channel): Message
+    {
+        return $this->createMessage()->to($channel);
+    }
+
+    /**
+     * @param null|string $text
+     * @return Message
+     */
+    public function send(?string $text = null): Message
+    {
+        return $this->createMessage()->send($text);
+    }
+
+    /**
      * Create a new message with defaults.
      *
      * @return \Nexy\Slack\Message

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -38,7 +38,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
 
         $client = new Client('http://fake.endpoint', [], $this->mockHttpClient);
 
-        $message = $client->createMessage()->to('@regan')->from('Archer')->setText('Message');
+        $message = $client->to('@regan')->from('Archer')->setText('Message');
 
         $client->sendMessage($message);
 

--- a/tests/ClientUnitTest.php
+++ b/tests/ClientUnitTest.php
@@ -66,7 +66,7 @@ class ClientUnitTest extends PHPUnit\Framework\TestCase
     {
         $client = new Client('http://fake.endpoint', [], new \Http\Mock\Client());
 
-        $message = $client->createMessage()->to('@regan');
+        $message = $client->to('@regan');
 
         $this->assertInstanceOf('Nexy\Slack\Message', $message);
 


### PR DESCRIPTION
Partial revert of #31. We keep some method but the `__call` magic one is still removed.