### PR TITLE
HTTPlug 2.0 support, misc. updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 script:
   - if [ "$LINT" = "1" ]; then composer validate; fi;
   - if [ "$LINT" = "1" ]; then php php-cs-fixer.phar fix --verbose --dry-run; fi;
-  - if [ "$LINT" != "1" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi;
+  - if [ "$LINT" != "1" ]; then mkdir -p build/logs && vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi;
 
 after_script:
   - if [ "$LINT" != "1" ]; coveralls -v; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 script:
   - if [ "$LINT" = "1" ]; then composer validate; fi;
   - if [ "$LINT" = "1" ]; then php php-cs-fixer.phar fix --verbose --dry-run; fi;
-  - if [ "$LINT" != "1" ]; then mkdir -p build/logs && vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi;
+  - if [ "$LINT" != "1" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
 
 after_script:
   - if [ "$LINT" != "1" ]; coveralls -v; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 script:
   - if [ "$LINT" = "1" ]; then composer validate; fi;
   - if [ "$LINT" = "1" ]; then php php-cs-fixer.phar fix --verbose --dry-run; fi;
-  - if [ "$LINT" != "1" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
+  - if [ "$LINT" != "1" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi;
 
 after_script:
   - if [ "$LINT" != "1" ]; coveralls -v; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 env:
@@ -20,6 +21,7 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.2
       env: LINT="1"
+    - php: 7.3
   allow_failures:
     - php: nightly
     - env: SYMFONY_VERSION=dev-master

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "guzzlehttp/psr7": "^1.4",
         "mockery/mockery": "^1.0",
         "php-http/message": "^1.6",
-        "php-http/mock-client": "^1.2"
+        "php-http/mock-client": "^1.2",
+        "phpunit/phpunit": "^7.0"
     },
     "suggest": {
         "nexylan/slack-bundle": "Required for Symfony bundle support"

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "guzzlehttp/psr7": "^1.4",
         "mockery/mockery": "^1.0",
         "php-http/message": "^1.6",
-        "php-http/mock-client": "^1.2",
-        "phpunit/phpunit": "^7.0"
+        "php-http/mock-client": "^1.2"
     },
     "suggest": {
         "nexylan/slack-bundle": "Required for Symfony bundle support"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.1",
         "ext-mbstring": "*",
-        "php-http/client-common": "^1.7",
+        "php-http/client-common": "^1.9 || ^2.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.3",
         "symfony/options-resolver": "^3.4 || ^4.0"
@@ -26,7 +26,7 @@
         "guzzlehttp/psr7": "^1.4",
         "mockery/mockery": "^1.0",
         "php-http/message": "^1.6",
-        "php-http/mock-client": "^1.1"
+        "php-http/mock-client": "^1.2"
     },
     "suggest": {
         "nexylan/slack-bundle": "Required for Symfony bundle support"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">


### PR DESCRIPTION
With this PR:

- Support for HTTPlug 2.0 is added
- PHP 7.3 is added to the Travis test matrix

Note, `php-http/client-common` doesn't yet have a stable release, but forcibly installing `php-http/client-common:^2.0@rc` and running the tests does pass