### PR TITLE
Added option to create link buttons with URL, instead of just interactive buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for link buttons
 
 ## [2.2.0]
 ### Added

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -60,6 +60,13 @@ final class AttachmentAction
     private $value;
 
     /**
+     * Optional value. It can be used to create link buttons.
+     *
+     * @var string|null
+     */
+    private $url;
+
+    /**
      * Confirmation field.
      *
      * @var ActionConfirmation|null
@@ -141,13 +148,33 @@ final class AttachmentAction
     }
 
     /**
-     * @param string $value
+     * @param string|null $value
      *
      * @return AttachmentAction
      */
     public function setValue(?string $value): self
     {
         $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string|null $url
+     *
+     * @return AttachmentAction
+     */
+    public function setUrl(?string $url): self
+    {
+        $this->url = $url;
 
         return $this;
     }
@@ -179,13 +206,22 @@ final class AttachmentAction
      */
     public function toArray(): array
     {
-        return [
-            'name' => $this->name,
+        $array = [
             'text' => $this->text,
             'style' => $this->style,
             'type' => $this->type,
-            'value' => $this->value,
-            'confirm' => $this->confirm ? $this->confirm->toArray() : null,
         ];
+
+        // Link buttons do not require "name", "value" and "confirm" attributes.
+        // @see https://api.slack.com/docs/message-attachments#link_buttons
+        if (null !== $this->url) {
+            $array['url'] = $this->url;
+        } else {
+            $array['name'] = $this->name;
+            $array['value'] = $this->value;
+            $array['confirm'] = $this->confirm ? $this->confirm->toArray() : null;
+        }
+
+        return $array;
     }
 }

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -114,6 +114,10 @@ class AttachmentUnitTest extends PHPUnit\Framework\TestCase
                             ->setOkText('OK Text 2')
                             ->setDismissText('Dismiss Text 2')
                         ),
+                    (new AttachmentAction('Button Name 1', 'Button Label 1'))
+                        ->setStyle('default')
+                        ->setType('button')
+                        ->setUrl('https://www.google.com'),
                 ]
             )
         ;
@@ -149,10 +153,10 @@ class AttachmentUnitTest extends PHPUnit\Framework\TestCase
             ],
             'actions' => [
                 [
-                    'name' => 'Name 1',
                     'text' => 'Text 1',
                     'style' => 'default',
                     'type' => 'button',
+                    'name' => 'Name 1',
                     'value' => 'Value 1',
                     'confirm' => [
                         'title' => 'Title 1',
@@ -162,10 +166,10 @@ class AttachmentUnitTest extends PHPUnit\Framework\TestCase
                     ],
                 ],
                 [
-                    'name' => 'Name 2',
                     'text' => 'Text 2',
                     'style' => 'default',
                     'type' => 'button',
+                    'name' => 'Name 2',
                     'value' => 'Value 2',
                     'confirm' => [
                         'title' => 'Title 2',
@@ -173,6 +177,12 @@ class AttachmentUnitTest extends PHPUnit\Framework\TestCase
                         'ok_text' => 'OK Text 2',
                         'dismiss_text' => 'Dismiss Text 2',
                     ],
+                ],
+                [
+                    'text' => 'Button Label 1',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'url' => 'https://www.google.com',
                 ],
             ],
         ];

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -268,6 +268,10 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
                             ->setOkText('OK Text 2')
                             ->setDismissText('Dismiss Text 2')
                         ),
+                    (new AttachmentAction('Button Name 1', 'Button Label 1'))
+                        ->setStyle('default')
+                        ->setType('button')
+                        ->setUrl('https://www.google.com'),
                 ]
             )
         ;
@@ -291,10 +295,10 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
             'fields' => [],
             'actions' => [
                 [
-                    'name' => 'Name 1',
                     'text' => 'Text 1',
                     'style' => 'default',
                     'type' => 'button',
+                    'name' => 'Name 1',
                     'value' => 'Value 1',
                     'confirm' => [
                         'title' => 'Title 1',
@@ -304,10 +308,10 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
                     ],
                 ],
                 [
-                    'name' => 'Name 2',
                     'text' => 'Text 2',
                     'style' => 'default',
                     'type' => 'button',
+                    'name' => 'Name 2',
                     'value' => 'Value 2',
                     'confirm' => [
                         'title' => 'Title 2',
@@ -315,6 +319,12 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
                         'ok_text' => 'OK Text 2',
                         'dismiss_text' => 'Dismiss Text 2',
                     ],
+                ],
+                [
+                    'text' => 'Button Label 1',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'url' => 'https://www.google.com',
                 ],
             ],
         ];


### PR DESCRIPTION
Closes #46 

Here is a simple example how to create link buttons: https://api.slack.com/docs/message-attachments#link_buttons