### PR TITLE
Use PSR-17 and PSR-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - The `Client::sendMessage()` method will now throw exceptions that match API errors
+- The `Client` instance does not depend to HTTPlug anymore thanks to PSR-17 and PSR-18 specifications
 
 ## [2.3.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@ The next releases will be under the MIT license. See the current [LICENSE](LICEN
 You can install the package using the [Composer](https://getcomposer.org/) package manager. You can install it by running this command in your project root:
 
 ```sh
-composer require nexylan/slack php-http/guzzle6-adapter
+composer require nexylan/slack
 ```
 
-Why `php-http/guzzle6-adapter`? We are decoupled from any HTTP messaging client thanks to [HTTPlug](http://httplug.io/).
+We also follow
+[PSR-7](https://www.php-fig.org/psr/psr-7/),
+[PSR-17](https://www.php-fig.org/psr/psr-17/) and
+[PSR-18](https://www.php-fig.org/psr/psr-18/) standards for HTTP messaging.
+It allows you to use any HTTP client following this convention and make the library maintenability better for us.
+
+So you need to install an HTTP client following those standards.
+We recommand to use the popular [HTTPlug](http://httplug.io/) project, but you are free to choose the more convinient one for you.
 
 Then [create an incoming webhook](https://my.slack.com/services/new/incoming-webhook) on your Slack account for the package to use.
 You'll need the webhook URL to instantiate the client (or for the configuration file if using Laravel).
@@ -48,21 +55,28 @@ You'll need the webhook URL to instantiate the client (or for the configuration 
 
 ### Instantiate the client
 
+In this example, we use the [HTTPlug discovery component](http://docs.php-http.org/en/latest/discovery.html) to bring the needed PSR tools.
+
 ```php
-// Instantiate without defaults
-$client = new Nexy\Slack\Client('https://hooks.slack.com/...');
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 
-// Instantiate with defaults, so all messages created
-// will be sent from 'Cyril' and to the #accounting channel
-// by default. Any names like @regan or #channel will also be linked.
-$settings = [
-	'username' => 'Cyril',
-	'channel' => '#accounting',
-	'link_names' => true
-];
+use Nexy\Slack\Client;
 
-$client = new Nexy\Slack\Client('https://hooks.slack.com/...', $settings);
+$client = new Client(
+    Psr18ClientDiscovery::find(),
+    Psr17FactoryDiscovery::findRequestFactory(),
+    Psr17FactoryDiscovery::findStreamFactory(),
+    'https://hooks.slack.com/...',
+    [
+        'username' => 'Cyril', // Default messages are sent from 'Cyril'
+        'channel' => '#accounting', // Default messages are sent to '#accounting'
+        'link_names' => true
+    ]
+);
 ```
+
+Note: The `$options` last parameter is optional.
 
 #### Settings
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,19 @@
     "require": {
         "php": "^7.1",
         "ext-mbstring": "*",
-        "php-http/client-common": "^1.9 || ^2.0",
-        "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^1.3",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0",
         "symfony/options-resolver": "^3.4 || ^4.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.4",
         "mockery/mockery": "^1.0",
+        "nyholm/psr7": "^1.1",
+        "php-http/discovery": "^1.7",
+        "php-http/httplug": "^2.0",
         "php-http/message": "^1.6",
-        "php-http/mock-client": "^1.2"
+        "php-http/mock-client": "^1.3"
     },
     "suggest": {
         "nexylan/slack-bundle": "Required for Symfony bundle support"

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Http\Discovery\Psr17FactoryDiscovery;
 use Nexy\Slack\ActionConfirmation;
 use Nexy\Slack\Attachment;
 use Nexy\Slack\AttachmentAction;
@@ -19,6 +20,9 @@ use Nexy\Slack\Client;
 
 class ClientFunctionalTest extends PHPUnit\Framework\TestCase
 {
+    /**
+     * @var \Http\Mock\Client
+     */
     private $mockHttpClient;
 
     protected function setUp(): void
@@ -39,7 +43,13 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
             'attachments' => [],
         ];
 
-        $client = new Client('http://fake.endpoint', [], $this->mockHttpClient);
+        $client = new Client(
+            $this->mockHttpClient,
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+            'http://fake.endpoint',
+            []
+        );
 
         $message = $client->to('@regan')->from('Archer')->setText('Message');
 
@@ -47,7 +57,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
 
         $this->assertSame(
             $expectedHttpData,
-            \json_decode($this->mockHttpClient->getLastRequest()->getBody()->getContents(), true)
+            \json_decode((string) $this->mockHttpClient->getLastRequest()->getBody(), true)
         );
     }
 
@@ -64,10 +74,16 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
             'attachments' => [],
         ];
 
-        $client = new Client('http://fake.endpoint', [
-            'channel' => '#default',
-            'sticky_channel' => true,
-        ], $this->mockHttpClient);
+        $client = new Client(
+            $this->mockHttpClient,
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+            'http://fake.endpoint',
+            [
+                'channel' => '#default',
+                'sticky_channel' => true,
+            ]
+        );
 
         $message = $client->to('@regan')->from('Archer')->setText('Message');
 
@@ -75,7 +91,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
 
         $this->assertSame(
             $expectedHttpData,
-            \json_decode($this->mockHttpClient->getLastRequest()->getBody()->getContents(), true)
+            \json_decode((string) $this->mockHttpClient->getLastRequest()->getBody(), true)
         );
     }
 
@@ -95,13 +111,18 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
             ->setThumbUrl('http://fake.host/image.png')
             ->setAuthorName('Joe Bloggs')
             ->setAuthorLink('http://fake.host/')
-            ->setAuthorIcon('http://fake.host/image.png')
-        ;
+            ->setAuthorIcon('http://fake.host/image.png');
 
-        $client = new Client('http://fake.endpoint', [
-            'username' => 'Test',
-            'channel' => '#general',
-        ], $this->mockHttpClient);
+        $client = new Client(
+            $this->mockHttpClient,
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+            'http://fake.endpoint',
+            [
+                'username' => 'Test',
+                'channel' => '#general',
+            ]
+        );
 
         $message = $client->createMessage()->setText('Message');
 
@@ -143,7 +164,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
 
         $this->assertSame(
             $expectedHttpData,
-            \json_decode($this->mockHttpClient->getLastRequest()->getBody()->getContents(), true)
+            \json_decode((string) $this->mockHttpClient->getLastRequest()->getBody(), true)
         );
     }
 
@@ -170,8 +191,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
                     (new AttachmentField('Field 1', 'Value 1')),
                     (new AttachmentField('Field 2', 'Value 2')),
                 ]
-            )
-        ;
+            );
 
         $attachmentOutput = [
             'fallback' => 'Some fallback text',
@@ -190,24 +210,30 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
             'fields' => [
-              [
-                'title' => 'Field 1',
-                'value' => 'Value 1',
-                'short' => false,
-              ],
-              [
-                'title' => 'Field 2',
-                'value' => 'Value 2',
-                'short' => false,
-              ],
+                [
+                    'title' => 'Field 1',
+                    'value' => 'Value 1',
+                    'short' => false,
+                ],
+                [
+                    'title' => 'Field 2',
+                    'value' => 'Value 2',
+                    'short' => false,
+                ],
             ],
             'actions' => [],
         ];
 
-        $client = new Client('http://fake.endpoint', [
-            'username' => 'Test',
-            'channel' => '#general',
-        ], $this->mockHttpClient);
+        $client = new Client(
+            $this->mockHttpClient,
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+            'http://fake.endpoint',
+            [
+                'username' => 'Test',
+                'channel' => '#general',
+            ]
+        );
 
         $message = $client->createMessage()->setText('Message');
 
@@ -228,7 +254,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
 
         $this->assertSame(
             $expectedHttpData,
-            \json_decode($this->mockHttpClient->getLastRequest()->getBody()->getContents(), true)
+            \json_decode((string) $this->mockHttpClient->getLastRequest()->getBody(), true)
         );
     }
 
@@ -273,8 +299,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
                         ->setType('button')
                         ->setUrl('https://www.google.com'),
                 ]
-            )
-        ;
+            );
 
         $attachmentOutput = [
             'fallback' => 'Some fallback text',
@@ -329,10 +354,16 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
             ],
         ];
 
-        $client = new Client('http://fake.endpoint', [
-            'username' => 'Test',
-            'channel' => '#general',
-        ], $this->mockHttpClient);
+        $client = new Client(
+            $this->mockHttpClient,
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+            'http://fake.endpoint',
+            [
+                'username' => 'Test',
+                'channel' => '#general',
+            ]
+        );
 
         $message = $client->createMessage()->setText('Message');
 
@@ -353,7 +384,7 @@ class ClientFunctionalTest extends PHPUnit\Framework\TestCase
 
         $this->assertSame(
             $expectedHttpData,
-            \json_decode($this->mockHttpClient->getLastRequest()->getBody()->getContents(), true)
+            \json_decode((string) $this->mockHttpClient->getLastRequest()->getBody(), true)
         );
     }
 }

--- a/tests/ClientUnitTest.php
+++ b/tests/ClientUnitTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Http\Discovery\Psr17FactoryDiscovery;
 use Nexy\Slack\Client;
 
 class ClientUnitTest extends PHPUnit\Framework\TestCase
@@ -18,9 +19,11 @@ class ClientUnitTest extends PHPUnit\Framework\TestCase
     public function testInstantiationWithNoDefaults(): void
     {
         $client = new Client(
+            new \Http\Mock\Client(),
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
             'http://fake.endpoint',
-            [],
-            new \Http\Mock\Client()
+            []
         );
 
         $this->assertInstanceOf(Client::class, $client);
@@ -41,9 +44,11 @@ class ClientUnitTest extends PHPUnit\Framework\TestCase
         ];
 
         $client = new Client(
+            new \Http\Mock\Client(),
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
             'http://fake.endpoint',
-            $defaults,
-            new \Http\Mock\Client()
+            $defaults
         );
 
         $this->assertSame($defaults, $client->getOptions());
@@ -64,9 +69,11 @@ class ClientUnitTest extends PHPUnit\Framework\TestCase
         ];
 
         $client = new Client(
+            new \Http\Mock\Client(),
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
             'http://fake.endpoint',
-            $defaults,
-            new \Http\Mock\Client()
+            $defaults
         );
 
         $message = $client->createMessage();
@@ -79,9 +86,11 @@ class ClientUnitTest extends PHPUnit\Framework\TestCase
     public function testWildcardCallToMessage(): void
     {
         $client = new Client(
+            new \Http\Mock\Client(),
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
             'http://fake.endpoint',
-            [],
-            new \Http\Mock\Client()
+            []
         );
 
         $message = $client->to('@regan');

--- a/tests/MessageUnitTest.php
+++ b/tests/MessageUnitTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Http\Discovery\Psr17FactoryDiscovery;
 use Nexy\Slack\Attachment;
 use Nexy\Slack\Client;
 use Nexy\Slack\Message;
@@ -172,9 +173,11 @@ class MessageUnitTest extends PHPUnit\Framework\TestCase
     {
         return new Message(
             new Client(
+                new \Http\Mock\Client(),
+                Psr17FactoryDiscovery::findRequestFactory(),
+                Psr17FactoryDiscovery::findStreamFactory(),
                 'http://fake.com',
-                [],
-                new \Http\Mock\Client()
+                []
             )
         );
     }


### PR DESCRIPTION
The goal is to get rid of any HTTP library management and let this to user choice.

We only need to match the interfaces.

- [x] Working tests
- [x] Usage documentation update
- [x] Changelog update