### PR TITLE
Add interfaces for client and message

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Nexy\Slack;
 
 use Nexy\Slack\Exception\SlackApiException;
-use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Client
+final class Client implements ClientInterface
 {
     /**
      * @var ErrorResponseHandler
@@ -40,7 +40,7 @@ final class Client
     private $options;
 
     /**
-     * @var ClientInterface
+     * @var HttpClientInterface
      */
     private $httpClient;
 
@@ -58,7 +58,7 @@ final class Client
      * @param mixed[] $options
      */
     public function __construct(
-        ClientInterface $httpClient,
+        HttpClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
         StreamFactoryInterface $streamFactory,
         string $endpoint,

--- a/src/Client.php
+++ b/src/Client.php
@@ -118,9 +118,9 @@ final class Client implements ClientInterface
     /**
      * Create a new message with defaults.
      *
-     * @return \Nexy\Slack\Message
+     * @return \Nexy\Slack\MessageInterface
      */
-    public function createMessage(): Message
+    public function createMessage(): MessageInterface
     {
         return (new Message($this))
             ->setChannel($this->options['channel'])
@@ -134,14 +134,14 @@ final class Client implements ClientInterface
     /**
      * Send a message.
      *
-     * @param \Nexy\Slack\Message $message
+     * @param \Nexy\Slack\MessageInterface $message
      *
      * @throws \RuntimeException
      * @throws \Psr\Http\Client\Exception
      * @throws SlackApiException
      * @throws \Http\Client\Exception
      */
-    public function sendMessage(Message $message): void
+    public function sendMessage(MessageInterface $message): void
     {
         // Ensure the message will always be sent to the default channel if asked for.
         if ($this->options['sticky_channel']) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -103,9 +103,9 @@ final class Client implements ClientInterface
      * @param string $name      The name of the method
      * @param array  $arguments The method arguments
      *
-     * @return \Nexy\Slack\Message
+     * @return \Nexy\Slack\MessageInterface
      */
-    public function __call(string $name, array $arguments): Message
+    public function __call(string $name, array $arguments): MessageInterface
     {
         return \call_user_func_array([$this->createMessage(), $name], $arguments);
     }
@@ -168,9 +168,9 @@ final class Client implements ClientInterface
     /**
      * Prepares the payload to be sent to the webhook.
      *
-     * @param \Nexy\Slack\Message $message The message to send
+     * @param \Nexy\Slack\MessageInterface $message The message to send
      */
-    private function preparePayload(Message $message): array
+    private function preparePayload(MessageInterface $message): array
     {
         $payload = [
             'text' => $message->getText(),
@@ -194,9 +194,9 @@ final class Client implements ClientInterface
     /**
      * Get the attachments in array form.
      *
-     * @param \Nexy\Slack\Message $message
+     * @param \Nexy\Slack\MessageInterface $message
      */
-    private function getAttachmentsAsArrays(Message $message): array
+    private function getAttachmentsAsArrays(MessageInterface $message): array
     {
         $attachments = [];
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -15,6 +15,6 @@ namespace Nexy\Slack;
 
 interface ClientInterface
 {
-    public function createMessage(): Message;
-    public function sendMessage(Message $message): void;
+    public function createMessage(): MessageInterface;
+    public function sendMessage(MessageInterface $message): void;
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nexylan packages.
+ *
+ * (c) Nexylan SAS <contact@nexylan.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nexy\Slack;
+
+interface ClientInterface
+{
+    public function createMessage(): Message;
+    public function sendMessage(Message $message): void;
+}

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -16,5 +16,6 @@ namespace Nexy\Slack;
 interface ClientInterface
 {
     public function createMessage(): MessageInterface;
+
     public function sendMessage(MessageInterface $message): void;
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -16,7 +16,7 @@ namespace Nexy\Slack;
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Message
+final class Message implements MessageInterface
 {
     /**
      * Reference to the Slack client responsible for sending
@@ -114,7 +114,7 @@ final class Message
      *
      * @return $this
      */
-    public function setText(?string $text): self
+    public function setText(?string $text): MessageInterface
     {
         $this->text = $text;
 
@@ -131,7 +131,7 @@ final class Message
      *
      * @return $this
      */
-    public function setChannel(?string $channel): self
+    public function setChannel(?string $channel): MessageInterface
     {
         $this->channel = $channel;
 
@@ -148,7 +148,7 @@ final class Message
      *
      * @return $this
      */
-    public function setUsername(?string $username): self
+    public function setUsername(?string $username): MessageInterface
     {
         $this->username = $username;
 
@@ -165,7 +165,7 @@ final class Message
      *
      * @return $this
      */
-    public function setIcon(?string $icon): self
+    public function setIcon(?string $icon): MessageInterface
     {
         if (null === $icon) {
             $this->icon = $this->iconType = null;
@@ -200,19 +200,19 @@ final class Message
      *
      * @return Message
      */
-    public function setAllowMarkdown(bool $value): self
+    public function setAllowMarkdown(bool $value): MessageInterface
     {
         $this->allowMarkdown = $value;
 
         return $this;
     }
 
-    public function enableMarkdown(): self
+    public function enableMarkdown(): MessageInterface
     {
         return $this->setAllowMarkdown(true);
     }
 
-    public function disableMarkdown(): self
+    public function disableMarkdown(): MessageInterface
     {
         return $this->setAllowMarkdown(false);
     }
@@ -228,7 +228,7 @@ final class Message
      *
      * @return Message
      */
-    public function setMarkdownInAttachments(array $fields): self
+    public function setMarkdownInAttachments(array $fields): MessageInterface
     {
         $this->markdownInAttachments = $fields;
 
@@ -240,7 +240,7 @@ final class Message
      *
      * @return $this
      */
-    public function from(string $username): self
+    public function from(string $username): MessageInterface
     {
         return $this->setUsername($username);
     }
@@ -250,7 +250,7 @@ final class Message
      *
      * @return $this
      */
-    public function to(string $channel): self
+    public function to(string $channel): MessageInterface
     {
         return $this->setChannel($channel);
     }
@@ -260,7 +260,7 @@ final class Message
      *
      * @return $this
      */
-    public function withIcon(string $icon): self
+    public function withIcon(string $icon): MessageInterface
     {
         return $this->setIcon($icon);
     }
@@ -270,7 +270,7 @@ final class Message
      *
      * @return $this
      */
-    public function attach(Attachment $attachment): self
+    public function attach(Attachment $attachment): MessageInterface
     {
         $this->attachments[] = $attachment;
 
@@ -290,7 +290,7 @@ final class Message
      *
      * @return $this
      */
-    public function setAttachments(array $attachments): self
+    public function setAttachments(array $attachments): MessageInterface
     {
         $this->clearAttachments();
 
@@ -306,7 +306,7 @@ final class Message
      *
      * @return $this
      */
-    public function clearAttachments(): self
+    public function clearAttachments(): MessageInterface
     {
         $this->attachments = [];
 
@@ -320,7 +320,7 @@ final class Message
      *
      * @return Message
      */
-    public function send(?string $text = null): self
+    public function send(?string $text = null): MessageInterface
     {
         if ($text) {
             $this->setText($text);

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -2,36 +2,66 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Nexylan packages.
+ *
+ * (c) Nexylan SAS <contact@nexylan.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nexy\Slack;
 
 interface MessageInterface
 {
     public function getText(): ?string;
-    public function setText(?string $text): MessageInterface;
+
+    public function setText(?string $text): self;
+
     public function getChannel(): ?string;
-    public function setChannel(?string $channel): MessageInterface;
+
+    public function setChannel(?string $channel): self;
+
     public function getUsername(): ?string;
-    public function setUsername(?string $username): MessageInterface;
+
+    public function setUsername(?string $username): self;
+
     public function getIcon(): ?string;
-    public function setIcon(?string $icon): MessageInterface;
+
+    public function setIcon(?string $icon): self;
+
     public function getIconType(): ?string;
+
     public function getAllowMarkdown(): bool;
-    public function setAllowMarkdown(bool $value): MessageInterface;
-    public function enableMarkdown(): MessageInterface;
-    public function disableMarkdown(): MessageInterface;
+
+    public function setAllowMarkdown(bool $value): self;
+
+    public function enableMarkdown(): self;
+
+    public function disableMarkdown(): self;
+
     public function getMarkdownInAttachments(): array;
-    public function setMarkdownInAttachments(array $fields): MessageInterface;
-    public function from(string $username): MessageInterface;
-    public function to(string $channel): MessageInterface;
-    public function withIcon(string $icon): MessageInterface;
-    public function attach(Attachment $attachment): MessageInterface;
+
+    public function setMarkdownInAttachments(array $fields): self;
+
+    public function from(string $username): self;
+
+    public function to(string $channel): self;
+
+    public function withIcon(string $icon): self;
+
+    public function attach(Attachment $attachment): self;
+
     /** @return Attachment[] */
     public function getAttachments(): array;
+
     /**
      * @param Attachment[] $attachments
-     * @return MessageInterface
      */
-    public function setAttachments(array $attachments): MessageInterface;
-    public function clearAttachments(): MessageInterface;
-    public function send(?string $text = null): MessageInterface;
+    public function setAttachments(array $attachments): self;
+
+    public function clearAttachments(): self;
+
+    public function send(?string $text = null): self;
 }

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nexy\Slack;
+
+interface MessageInterface
+{
+    public function getText(): ?string;
+    public function setText(?string $text): MessageInterface;
+    public function getChannel(): ?string;
+    public function setChannel(?string $channel): MessageInterface;
+    public function getUsername(): ?string;
+    public function setUsername(?string $username): MessageInterface;
+    public function getIcon(): ?string;
+    public function setIcon(?string $icon): MessageInterface;
+    public function getIconType(): ?string;
+    public function getAllowMarkdown(): bool;
+    public function setAllowMarkdown(bool $value): MessageInterface;
+    public function enableMarkdown(): MessageInterface;
+    public function disableMarkdown(): MessageInterface;
+    public function getMarkdownInAttachments(): array;
+    public function setMarkdownInAttachments(array $fields): MessageInterface;
+    public function from(string $username): MessageInterface;
+    public function to(string $channel): MessageInterface;
+    public function withIcon(string $icon): MessageInterface;
+    public function attach(Attachment $attachment): MessageInterface;
+    /** @return Attachment[] */
+    public function getAttachments(): array;
+    /**
+     * @param Attachment[] $attachments
+     * @return MessageInterface
+     */
+    public function setAttachments(array $attachments): MessageInterface;
+    public function clearAttachments(): MessageInterface;
+    public function send(?string $text = null): MessageInterface;
+}


### PR DESCRIPTION
By adding interfaces the classes can be mocked in the tests of implementing projects/packages.
Alternatively the `final` keyword could be removed.

What do you think?