### PR TITLE
Return response in sendMessage method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
   - if [ "$LINT" != "1" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
 
 after_script:
-  - if [ "$LINT" != "1" ]; coveralls -v; fi;
+  - if [ "$LINT" != "1" ]; then coveralls -v; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
   - if [ "$LINT" != "1" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
 
 after_script:
-  - if [ "$LINT" != "1" ]; then coveralls -v; fi;
+  - if [ "$LINT" != "1" ]; coveralls -v; fi;

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0"
+        "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0",
+        "zakirullin/mess": "^0.7|^1.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
         "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0",
-        "zakirullin/mess": "^0.7|^1.0"
+        "zakirullin/mess": "^0.7 || ^1.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.4",

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,6 +18,8 @@ use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Zakirullin\Mess\Mess;
+use Zakirullin\Mess\MessInterface;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -135,13 +137,13 @@ final class Client implements ClientInterface
      * Send a message.
      *
      * @param \Nexy\Slack\MessageInterface $message
-     *
+     * @return MessInterface
      * @throws \RuntimeException
      * @throws \Psr\Http\Client\Exception
      * @throws SlackApiException
      * @throws \Http\Client\Exception
      */
-    public function sendMessage(MessageInterface $message): void
+    public function sendMessage(MessageInterface $message): MessInterface
     {
         // Ensure the message will always be sent to the default channel if asked for.
         if ($this->options['sticky_channel']) {
@@ -163,6 +165,8 @@ final class Client implements ClientInterface
         );
 
         $this->errorResponseHandler->handleResponse($response);
+
+        return new Mess(\json_decode((string)$response->getBody(), true));
     }
 
     /**

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Nexy\Slack;
 
+use Zakirullin\Mess\MessInterface;
+
 interface ClientInterface
 {
     public function createMessage(): MessageInterface;
 
-    public function sendMessage(MessageInterface $message): void;
+    public function sendMessage(MessageInterface $message): MessInterface;
 }


### PR DESCRIPTION
Hello there.
We should have a possibility to send a reply to the previously sent message, wich seems to be impossible as for now, due to the absence of response itself. There's a `ts` field in Slack's response, which is effectively a message's ID.

You may wonder:
Q: Why not to return `ResponseInterface` straight away?
A: Well, that's a low-level transport detail, which should not take place in our service layer. We should not expose those http-related details to the outer world.

Q: Why not to return a plain array so to avoid an extra dependency?
A: Arrays don't have contracts, it's better not to pass them all around the system. Also `json_decode` can return false. 

Q: Why not to use typed `ValueObject`?
A: API may change. They can break/add things. `Mess` allows us to tolerate Slack's changes. We should only fail if we can't get the **field we really need** (For example now we only need `ts` field, which is unlikely subject to change. Others may need `ok` or some other extra fields).

With all that being said, let's go down to the business:
_It's now possible to get sent message's ID_ - `$client->send($message)['ts']->getString()`.
It's type safe, with no PHP's magic type conversion involved.

**If you're ok with the solution - I'll fix Travis issues**

An example response:
```json
{
    "ok": true,
    "channel": "C1H9RESGL",
    "ts": "1503435956.000247",
    "message": {
        "text": "Here's a message for you",
        "username": "ecto1",
        "bot_id": "B19LU7CSY",
        "attachments": [
            {
                "text": "This is an attachment",
                "id": 1,
                "fallback": "This is an attachment's fallback"
            }
        ],
        "type": "message",
        "subtype": "bot_message",
        "ts": "1503435956.000247"
    }
}
```
